### PR TITLE
Fixed the eval_sick so that it works with the new Keras version

### DIFF
--- a/eval_sick.py
+++ b/eval_sick.py
@@ -70,7 +70,7 @@ def prepare_model(ninputs=9600, nclass=5):
     Set up and compile the model architecture (Logistic regression)
     """
     lrmodel = Sequential()
-    lrmodel.add(Dense(ninputs, nclass))
+    lrmodel.add(Dense(nclass, input_dim=ninputs))
     lrmodel.add(Activation('softmax'))
     lrmodel.compile(loss='categorical_crossentropy', optimizer='adam')
     return lrmodel


### PR DESCRIPTION
Right now the Logistic Regression model that is built with Keras to be used for evaluating semantic relatedness doesn't work with any new versions. This has a simple fix.